### PR TITLE
Handle curses bounds errors in matrix demo

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,1 +1,38 @@
+import curses
+import random
+import time
 
+
+def matrix(stdscr):
+    """Render a Matrix-style rain effect with bounds checking."""
+    curses.curs_set(0)
+    curses.start_color()
+    curses.init_pair(1, curses.COLOR_GREEN, curses.COLOR_BLACK)
+    stdscr.nodelay(True)
+
+    height, width = stdscr.getmaxyx()
+    columns = [0] * width
+
+    while True:
+        stdscr.erase()
+        height, width = stdscr.getmaxyx()
+        if len(columns) < width:
+            columns.extend([0] * (width - len(columns)))
+        elif len(columns) > width:
+            columns = columns[:width]
+
+        for i, y in enumerate(columns):
+            char = chr(random.randint(33, 126))
+            if 0 <= y < height and 0 <= i < width:
+                try:
+                    stdscr.addstr(y, i, char, curses.color_pair(1))
+                except curses.error:
+                    pass
+            columns[i] = y + 1 if y + 1 < height else 0
+
+        stdscr.refresh()
+        time.sleep(0.05)
+
+
+if __name__ == "__main__":
+    curses.wrapper(matrix)

--- a/main.py
+++ b/main.py
@@ -4,31 +4,43 @@ import time
 
 
 def matrix(stdscr):
-    """Render a Matrix-style rain effect with bounds checking."""
+    """Render cascading green text reminiscent of the Matrix."""
     curses.curs_set(0)
     curses.start_color()
     curses.init_pair(1, curses.COLOR_GREEN, curses.COLOR_BLACK)
     stdscr.nodelay(True)
 
     height, width = stdscr.getmaxyx()
-    columns = [0] * width
+    columns = [None] * width  # Track active streams per column
 
     while True:
         stdscr.erase()
         height, width = stdscr.getmaxyx()
         if len(columns) < width:
-            columns.extend([0] * (width - len(columns)))
+            columns.extend([None] * (width - len(columns)))
         elif len(columns) > width:
             columns = columns[:width]
 
-        for i, y in enumerate(columns):
-            char = chr(random.randint(33, 126))
-            if 0 <= y < height and 0 <= i < width:
-                try:
-                    stdscr.addstr(y, i, char, curses.color_pair(1))
-                except curses.error:
-                    pass
-            columns[i] = y + 1 if y + 1 < height else 0
+        for i, stream in enumerate(columns):
+            if stream is None:
+                # Randomly start a new stream
+                if random.random() < 0.02:
+                    length = random.randint(3, height // 2 or 1)
+                    columns[i] = {"y": 0, "length": length}
+            else:
+                y, length = stream["y"], stream["length"]
+                for offset in range(length):
+                    char_y = y - offset
+                    if 0 <= char_y < height:
+                        try:
+                            stdscr.addstr(
+                                char_y, i, chr(random.randint(33, 126)), curses.color_pair(1)
+                            )
+                        except curses.error:
+                            pass
+                stream["y"] += 1
+                if stream["y"] - length > height:
+                    columns[i] = None
 
         stdscr.refresh()
         time.sleep(0.05)


### PR DESCRIPTION
## Summary
- Initialize color pair for green-on-black output
- Guard writes to stay within window bounds and silence stray curses errors

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a178bdd5a083338bc0e7532f1bc0d7